### PR TITLE
Hide about header on mobile portrait

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -30,7 +30,7 @@ export default function About({}: Props) {
       />
 
       <div className="space-y-10 px-0 md:px-10">
-        <h4 className="s8:text-2xl 12pro:text-3xl sm:text-4xl font-semibold">
+        <h4 className="s8:text-2xl 12pro:text-3xl sm:text-4xl font-semibold hide-mobile-portrait">
           Here is a{" "}
           <span className="underline decoration-[#F7AB0A]/50">little</span>{" "}
           background

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,3 +11,9 @@
     @apply outline-none bg-slate-400/10 rounded-sm border-b s8:px-4 s8:py-2 sm:px-6 sm:py-4 border-[#242424] text-gray-500 placeholder-gray-500 transition-all focus:border-[#F7AB0A]/40 focus:text-[#F7AB0A]/40 hover:border-[#F7AB0A]/40;
   }
 }
+
+@media (max-width: 767px) and (orientation: portrait) {
+  .hide-mobile-portrait {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a utility class to hide the about section header on narrow portrait devices
- ensure the heading is hidden on mobile portrait viewports to prevent overlap with the image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6775be8588326a7d47b85727f5fc9