### PR TITLE
Make project descriptions scrollable on small screens

### DIFF
--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -429,7 +429,10 @@ function Projects({}: Props) {
                   </div>
                 )}
 
-                <p className="text-sm sm:text-base md:text-lg text-center">
+                <p
+                  className="text-sm sm:text-base md:text-lg text-center max-h-32 overflow-y-auto scrollbar-thin scrollbar-thumb-white/40 scrollbar-track-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-[#D1FE17]/60 sm:max-h-none sm:overflow-visible"
+                  tabIndex={0}
+                >
                   {project.description}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- allow each project description to scroll on compact layouts by capping its height and enabling overflow handling
- add focus styling and keyboard access so the scrollable region remains accessible

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e256ed5ea48326bd21d6a842bc8472